### PR TITLE
possible solution for the following bug

### DIFF
--- a/src/store/template.ts
+++ b/src/store/template.ts
@@ -106,8 +106,8 @@ export const useTemplateStore = createStore({
 				this.templates = {
 					id,
 					expenses: {
-						expenses,
 						...this.templates.expenses,
+						expenses,
 					},
 				};
 			}

--- a/src/store/template.ts
+++ b/src/store/template.ts
@@ -102,7 +102,14 @@ export const useTemplateStore = createStore({
 			const response = await postAuth(data);
 
 			if (response.success) {
-				this.templates = getDataFromResponse(response);
+				const { id, expenses } = getDataFromResponse(response);
+				this.templates = {
+					id,
+					expenses: {
+						expenses,
+						...this.templates.expenses,
+					},
+				};
 			}
 
 			return { success: response.success, error: response.error };


### PR DESCRIPTION
when a user goes to the budget edit page, only the banks info are being display. this is due to when a user saves a budget, the template saved with only the bank info, and that updates bank info overwrites the state.