### PR TITLE
the budget edit page details is not updating with the most recent dat…

### DIFF
--- a/src/views/dashboard/BudgetEdit.vue
+++ b/src/views/dashboard/BudgetEdit.vue
@@ -124,6 +124,7 @@ export default defineComponent({
 				if (isLatestBudget()) {
 					await aggregationStore.getUnpaidBillTotals();
 					await updateBudgetTemplate();
+					await templateStore.getTemplates();
 				}
 
 				await aggregationStore.getYearlyAggregations();


### PR DESCRIPTION
…a after saving a budget. so I get all the budget template when a user saves a budget